### PR TITLE
Add missing interactions in Select component

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "prettier": "prettier src/**/*.{tsx,ts} --write",
     "prettier:ci": "prettier src/**/*.{tsx,ts} --check",
     "lint-staged": "lint-staged -v",
-    "setup": "npm ci",
+    "setup": "npm ci && husky",
     "compile": "tsc -b",
     "build": "npm run compile && vite build",
     "build:storybook": "storybook build",

--- a/src/components/atoms/Select/index.mocks.json
+++ b/src/components/atoms/Select/index.mocks.json
@@ -34,11 +34,11 @@
       "showOptions": 3
     },
     "firstOptionSelected": {
+      "selectedValues": ["0"],
       "options": [
         {
           "id": 0,
-          "name": "Option 0",
-          "selected": true
+          "name": "Option 0"
         },
         {
           "id": 1,

--- a/src/components/atoms/Select/index.stories.tsx
+++ b/src/components/atoms/Select/index.stories.tsx
@@ -21,6 +21,12 @@ WithOneOption.args = testing.oneOption
 export const WithSeveralOptions = Template.bind({})
 WithSeveralOptions.args = testing.severalOptions
 
+export const Disabled = Template.bind({})
+Disabled.args = {
+  ...WithSeveralOptions.args,
+  isDisabled: true
+}
+
 export const ShowsThreeOptions = Template.bind({})
 ShowsThreeOptions.args = {
   ...testing.severalOptions,

--- a/src/components/atoms/Select/index.tsx
+++ b/src/components/atoms/Select/index.tsx
@@ -11,7 +11,9 @@ const Select: React.FC<SelectProps> = ({
   containerCssClasses = null,
   style = null,
   containerStyle = null,
+  isDisabled,
   options = [],
+  selectedValues,
   name,
   showOptions = 1,
   isMultiple = false,
@@ -52,18 +54,20 @@ const Select: React.FC<SelectProps> = ({
         data-testid={selectTestId}
         className={cssClasses ?? undefined}
         style={style ?? undefined}
+        defaultValue={selectedValues}
         name={name}
+        disabled={isDisabled ?? false}
         multiple={isMultiple}
         size={showOptions}
+        onClick={onClick}
+        onChange={onChange}
+        onBlur={onBlur}
       >
-        {options.map(({ id, name, selected }, i) => (
+        {options.map(({ id, name }, i) => (
           <option
             data-testid={`${selectTestId}-option-${i}`}
-            key={id.toString()}
-            defaultChecked={selected ?? false}
-            onClick={onClick}
-            onChange={onChange}
-            onBlur={onBlur}
+            key={`key-option-${id.toString()}`}
+            value={id.toString()}
           >
             {name}
           </option>

--- a/src/interfaces/atomProps.ts
+++ b/src/interfaces/atomProps.ts
@@ -219,15 +219,18 @@ export interface DeleteProps extends ElementProps, ClickeableProps {
 export interface SelectOption {
   id: string | number
   name: string
-  selected?: boolean
 }
 
 export interface SelectProps
   extends ComposedElementProps,
     InteractiveOnChangeProps,
     NamedInputProps {
-  /** `Attribute` Indicates the options contained on the select */
+  /** `Attribute` Will disable the input */
+  isDisabled?: boolean
+  /** `Attribute` Indicates the select contained on the select */
   options?: SelectOption[]
+  /** `Attribute` Will select a different default option if the user provides it. It can be an multiple selection if `isMultiple` is true */
+  selectedValues?: string | string[]
   /** `Attribute` Indicates how many options will be shown at first glance (before looking for the whole list */
   showOptions?: number
   /** `Attribute` Will allow multiple selection */


### PR DESCRIPTION
### Changes made 
- Moved all user interaction-related methods up to the `select` tag.
- Added `isDisabled` and `selectedValues` properties:
  - `isDisabled` was missing in former versions.
  - `selectedValues` will replace the former logic in the `option` tag and now in the `select` tag.

---

### My pull request is for
- [x] A bugfix
- [ ] A new component
- [x] An existing component update
- [ ] Dependencies version update

- In case of a `bug` or an `existing component update`
  - [x] Updated unit tests that reach at least 90% of code coverage.
  - [x] Updated interfaces, types, tuples, and enums for the impacted component/s

---

### Screenshots
N/A